### PR TITLE
Add SSL 3 and TLS 1.2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/**/.vs/
+/**/obj/
+/**/[Bb]in/
+/**/*.csproj.user
+/**/*.vspscc
+/**/*.vcxproj.user

--- a/SessionUploadExample/Program.cs
+++ b/SessionUploadExample/Program.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -83,6 +84,9 @@ namespace SessionUploadExample
             {
                 Program.PrintUsageAndExit();
             }
+
+            // Enable SSL 3 / TLS 1.2 support
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls12;
 
             string authCookie = null;
             string serverDns = null;


### PR DESCRIPTION
Add SSL 3 and TLS 1.2 support, which are now required for connecting to Panopto cloud sites.

Additionally added a .gitignore to automatically ignore files generated by Visual Studio